### PR TITLE
Fix unwrap class name method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 ### Fixed
 
+## [0.3.3]
+### Fixed
+- Fix unwrap_class_name, it was wrongly expecting an instance not a class.
+
 ## [0.3.2]
 ### Added
 - Implement a custom version of Sidekiq's display\_class\_name that fix an issues with ActiveJob > 6 when the job's class is passed as class not String

--- a/lib/sidekiq/instrumental/middleware/base.rb
+++ b/lib/sidekiq/instrumental/middleware/base.rb
@@ -70,7 +70,7 @@ module Sidekiq
           display_class = job.display_class
 
           if %w[ActionMailer::DeliveryJob ActionMailer::MailDeliveryJob]
-               .include?(display_class.class.name)
+               .include?(display_class.to_s)
             # The class name was not unwrapped correctly by the +display_class+ method
             job.args[0]['arguments'][0..1].join('#')
           else

--- a/lib/sidekiq/instrumental/version.rb
+++ b/lib/sidekiq/instrumental/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module Instrumental
-    VERSION = '0.3.2'
+    VERSION = '0.3.3'
   end
 end

--- a/spec/sidekiq/instrumental/middleware/client_spec.rb
+++ b/spec/sidekiq/instrumental/middleware/client_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Sidekiq::Instrumental::Middleware::Client do
     end
 
     context "when sidekiq's wrapped class is set as a Class" do
-      let(:wrapped_class) { stub_const('ActionMailer::DeliveryJob', Class.new).new }
+      let(:wrapped_class) { stub_const('ActionMailer::DeliveryJob', Class.new) }
 
       it 'unwraps the class name and increments the metric' do
         expect(middleware)

--- a/spec/sidekiq/instrumental/middleware/server_spec.rb
+++ b/spec/sidekiq/instrumental/middleware/server_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Sidekiq::Instrumental::Middleware::Server do
     end
 
     context "when sidekiq's wrapped class is set as a Class" do
-      let(:wrapped_class) { stub_const('ActionMailer::DeliveryJob', Class.new).new }
+      let(:wrapped_class) { stub_const('ActionMailer::DeliveryJob', Class.new) }
 
       it 'unwraps the class name and increments the metric' do
         expect(middleware)


### PR DESCRIPTION
## Change description

Made a mistake, I was passing an instance not a class on the tests. 

## Related issues

- Source: <Issue link or Spec Link>
- UAT: <UAT Link>
- QA: <QA Task Link here>
- Review app: <Link to Heroku>

## Checklists

### Development

- [ ] The commit message follows our [guidelines](https://docs.hubstaff.com/hubstaff-docs/latest/great_commit_messages.html)
- [ ] I have performed a self-review of my own code
- [ ] I have thoroughly tested the changes
- [ ] I have added tests that prove my fix is effective or that my feature works

### Security

- [ ] Security impact of change has been considered
