### PR TITLE
Add prometheus metrics

### DIFF
--- a/lib/sidekiq/instrumental/middleware/base.rb
+++ b/lib/sidekiq/instrumental/middleware/base.rb
@@ -32,6 +32,10 @@ module Sidekiq
 
         protected
 
+        def push_metrics
+          config.I.push
+        end
+
         def increment(*args)
           config.I.increment(*args)
         end

--- a/lib/sidekiq/instrumental/middleware/client.rb
+++ b/lib/sidekiq/instrumental/middleware/client.rb
@@ -6,17 +6,18 @@ module Sidekiq
       # Client side sidekiq middleware
       class Client < Base
         def track(_stats, worker_instance, msg, queue, _elapsed)
-          increment('sidekiq.queued')
+          increment('sidekiq_queued')
 
           return unless config.allowed_to_submit queue, worker_instance
 
-          base_key = "sidekiq.#{queue}."
+          base_key = "sidekiq_#{queue}_"
           increment(base_key + 'queued')
 
           display_class = unwrap_class_name(msg)
-          base_key += build_class_key(display_class) + '.'
+          base_key += build_class_key(display_class) + '_'
 
           increment(base_key + 'queued')
+          push_metrics
         end
       end
     end

--- a/lib/sidekiq/instrumental/middleware/client.rb
+++ b/lib/sidekiq/instrumental/middleware/client.rb
@@ -6,15 +6,15 @@ module Sidekiq
       # Client side sidekiq middleware
       class Client < Base
         def track(_stats, worker_instance, msg, queue, _elapsed)
-          increment('sidekiq_queued')
+          increment('sidekiq.queued')
 
           return unless config.allowed_to_submit queue, worker_instance
 
-          base_key = "sidekiq_#{queue}_"
+          base_key = "sidekiq.#{queue}."
           increment(base_key + 'queued')
 
           display_class = unwrap_class_name(msg)
-          base_key += build_class_key(display_class) + '_'
+          base_key += build_class_key(display_class) + '.'
 
           increment(base_key + 'queued')
           push_metrics

--- a/lib/sidekiq/instrumental/middleware/server.rb
+++ b/lib/sidekiq/instrumental/middleware/server.rb
@@ -12,7 +12,7 @@ module Sidekiq
 
           return unless config.allowed_to_submit queue, worker_instance
 
-          base_key = "sidekiq_#{queue}_"
+          base_key = "sidekiq.#{queue}."
 
           increment(base_key + 'processed')
           gauge(base_key + 'time', elapsed)
@@ -20,7 +20,7 @@ module Sidekiq
           gauge(base_key + 'latency', Sidekiq::Queue.new(queue.to_s).latency)
 
           display_class = unwrap_class_name(msg)
-          base_key += build_class_key(display_class) + '_'
+          base_key += build_class_key(display_class) + '.'
 
           increment(base_key + 'processed')
           gauge(base_key + 'time', elapsed)
@@ -29,13 +29,13 @@ module Sidekiq
         end
 
         def submit_general_stats(stats)
-          increment('sidekiq_processed')
+          increment('sidekiq.processed')
           {
             enqueued: nil,
             failed: nil,
             scheduled_size: 'scheduled'
           }.each do |method, name|
-            gauge("sidekiq_#{(name || method)}", stats.send(method).to_i)
+            gauge("sidekiq.#{(name || method)}", stats.send(method).to_i)
           end
         end
       end

--- a/lib/sidekiq/instrumental/middleware/server.rb
+++ b/lib/sidekiq/instrumental/middleware/server.rb
@@ -12,7 +12,7 @@ module Sidekiq
 
           return unless config.allowed_to_submit queue, worker_instance
 
-          base_key = "sidekiq.#{queue}."
+          base_key = "sidekiq_#{queue}_"
 
           increment(base_key + 'processed')
           gauge(base_key + 'time', elapsed)
@@ -20,20 +20,22 @@ module Sidekiq
           gauge(base_key + 'latency', Sidekiq::Queue.new(queue.to_s).latency)
 
           display_class = unwrap_class_name(msg)
-          base_key += build_class_key(display_class) + '.'
+          base_key += build_class_key(display_class) + '_'
 
           increment(base_key + 'processed')
           gauge(base_key + 'time', elapsed)
+
+          push_metrics
         end
 
         def submit_general_stats(stats)
-          increment('sidekiq.processed')
+          increment('sidekiq_processed')
           {
             enqueued: nil,
             failed: nil,
             scheduled_size: 'scheduled'
           }.each do |method, name|
-            gauge("sidekiq.#{(name || method)}", stats.send(method).to_i)
+            gauge("sidekiq_#{(name || method)}", stats.send(method).to_i)
           end
         end
       end

--- a/lib/sidekiq/instrumental/version.rb
+++ b/lib/sidekiq/instrumental/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module Instrumental
-    VERSION = '0.3.4'
+    VERSION = '0.3.5'
   end
 end

--- a/sidekiq-instrumental.gemspec
+++ b/sidekiq-instrumental.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_runtime_dependency 'instrumental_agent', '>= 0.13'
   spec.add_runtime_dependency 'sidekiq', '>= 4.0', '< 6.0'
 
   spec.add_development_dependency 'bundler'

--- a/spec/sidekiq/instrumental/middleware/client_spec.rb
+++ b/spec/sidekiq/instrumental/middleware/client_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Sidekiq::Instrumental::Middleware::Client do
   before do
     allow(config).to receive(:enabled?).and_return(true)
     allow(middleware).to receive(:increment)
+    allow(middleware).to receive(:push_metrics)
     allow(::Sidekiq::Stats).to receive(:new).and_return(sidekiq_stats)
   end
 

--- a/spec/sidekiq/instrumental/middleware/server_spec.rb
+++ b/spec/sidekiq/instrumental/middleware/server_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Sidekiq::Instrumental::Middleware::Server do
     allow(config).to receive(:enabled?).and_return(true)
     allow(middleware).to receive(:increment)
     allow(middleware).to receive(:gauge)
+    allow(middleware).to receive(:push_metrics)
     allow(::Sidekiq::Stats).to receive(:new).and_return(sidekiq_stats)
     allow(::Sidekiq::Queue).to receive(:new).and_return(sidekiq_queue)
   end


### PR DESCRIPTION
## Change description

Send metrics to Prometheus pushgateway instead of InstrumentalApp
Explicit `push` call is needed to push sidekiq metrics to Pushgateway, otherwise the data will be kept in memory forever waiting for Prometheus to scrape it.

## Related issues

- Source: [Epic](https://tasks.hubstaff.com/app/organizations/55/epics/9759)
- UAT: <UAT Link>
- QA: <QA Task Link here>
- Review app: <Link to Heroku>

## Checklists

### Development

- [ ] The commit message follows our [guidelines](https://docs.hubstaff.com/hubstaff-docs/latest/great_commit_messages.html)
- [ ] I have performed a self-review of my own code
- [ ] I have thoroughly tested the changes
- [ ] I have added tests that prove my fix is effective or that my feature works

### Security

- [ ] Security impact of change has been considered
